### PR TITLE
Remove k4DataSvc that no longer exists in k4FWCore

### DIFF
--- a/k4MLJetTagger/options/createJetMCTag.py
+++ b/k4MLJetTagger/options/createJetMCTag.py
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 from Gaudi.Configuration import INFO
-from Configurables import JetMCTagger
-from Configurables import k4DataSvc
+from Configurables import JetMCTagger, EventDataSvc
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
 
@@ -43,6 +42,6 @@ transformer = JetMCTagger("JetMCTagger",
 ApplicationMgr(TopAlg=[transformer],
                EvtSel="NONE",
                EvtMax=args.num_ev,
-               ExtSvc=[k4DataSvc("EventDataSvc")],
+               ExtSvc=[EventDataSvc("EventDataSvc")],
                OutputLevel=INFO,
                )

--- a/k4MLJetTagger/options/createJetTags.py
+++ b/k4MLJetTagger/options/createJetTags.py
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 from Gaudi.Configuration import INFO
-from Configurables import JetTagger
-from Configurables import k4DataSvc
+from Configurables import JetTagger, EventDataSvc
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
 
@@ -57,6 +56,6 @@ transformer = JetTagger("JetTagger",
 ApplicationMgr(TopAlg=[transformer],
                EvtSel="NONE",
                EvtMax=args.num_ev,
-               ExtSvc=[k4DataSvc("EventDataSvc")],
+               ExtSvc=[EventDataSvc("EventDataSvc")],
                OutputLevel=INFO,
                )

--- a/k4MLJetTagger/options/writeJetConstObs.py
+++ b/k4MLJetTagger/options/writeJetConstObs.py
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 from Gaudi.Configuration import INFO, WARNING
-from Configurables import JetObsWriter
-from Configurables import k4DataSvc
+from Configurables import JetObsWriter, EventDataSvc
 from Configurables import THistSvc
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
@@ -54,6 +53,6 @@ algList.append(MyJetObsWriter)
 ApplicationMgr(TopAlg=algList,
                EvtSel="NONE",
                EvtMax=args.num_ev,
-               ExtSvc=[k4DataSvc("EventDataSvc")],
+               ExtSvc=[EventDataSvc("EventDataSvc")],
                OutputLevel=INFO,
                )

--- a/k4MLJetTagger/options/writeJetTags.py
+++ b/k4MLJetTagger/options/writeJetTags.py
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 from Gaudi.Configuration import INFO, WARNING
-from Configurables import JetTagWriter, JetTagger, JetMCTagger
-from Configurables import k4DataSvc
+from Configurables import JetTagWriter, JetTagger, JetMCTagger, EventDataSvc
 from Configurables import THistSvc
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
@@ -81,6 +80,6 @@ algList.append(MyJetTagWriter)
 ApplicationMgr(TopAlg=algList,
                EvtSel="NONE",
                EvtMax=args.num_ev,
-               ExtSvc=[k4DataSvc("EventDataSvc")],
+               ExtSvc=[EventDataSvc("EventDataSvc")],
                OutputLevel=INFO,
                )


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove k4DataSvc that no longer exists in k4FWCore, following https://github.com/key4hep/k4FWCore/pull/392

ENDRELEASENOTES